### PR TITLE
fix deprecated warning

### DIFF
--- a/05_model_evaluation.ipynb
+++ b/05_model_evaluation.ipynb
@@ -304,7 +304,7 @@
    "outputs": [],
    "source": [
     "# STEP 1: split X and y into training and testing sets\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.4, random_state=4)"
    ]
   },


### PR DESCRIPTION
running this code will give you this error: 

```
DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
  "This module will be removed in 0.20.", DeprecationWarning)
```

this will fix the error using the new `sklearn.model_selection` instead.
