### PR TITLE
python-3-zip

### DIFF
--- a/06_linear_regression.ipynb
+++ b/06_linear_regression.ipynb
@@ -664,7 +664,7 @@
    ],
    "source": [
     "# pair the feature names with the coefficients\n",
-    "zip(feature_cols, linreg.coef_)"
+    "list(zip(feature_cols, linreg.coef_))"
    ]
   },
   {


### PR DESCRIPTION
In python 3, zip returns an object. So we need to use list to print them as lists.
SO : http://stackoverflow.com/questions/19777612/python-range-and-zip-object-type
